### PR TITLE
Constructor dependency injection + routes naming

### DIFF
--- a/src/main/kotlin/org/breizhcamp/talk/tweetmockserver/controller/TweetController.kt
+++ b/src/main/kotlin/org/breizhcamp/talk/tweetmockserver/controller/TweetController.kt
@@ -2,7 +2,6 @@ package org.breizhcamp.talk.tweetmockserver.controller
 
 import org.breizhcamp.talk.tweetmockserver.model.Tweet
 import org.breizhcamp.talk.tweetmockserver.service.TweetService
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -14,22 +13,19 @@ import reactor.core.publisher.toMono
 import java.time.Duration
 
 @RestController
-class TweetController {
+class TweetController(private val tweetService: TweetService) {
 
-    @Autowired
-    private lateinit var tweetService: TweetService
-
-    @GetMapping("/tweet")
+    @GetMapping("/tweets")
     fun getTweets(): Flux<Tweet> {
         return tweetService.generateTweets(50).toFlux()
     }
 
-    @GetMapping("/tweet/{id}")
+    @GetMapping("/tweets/{id}")
     fun getTweet(@PathVariable id: Long): Mono<Tweet> {
         return tweetService.generateTweet(id).toMono()
     }
 
-    @GetMapping(path = ["/tweet-stream"], produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    @GetMapping(path = ["/tweets"], produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     fun getStreamTweets(): Flux<Tweet> {
         return Flux.interval(Duration.ofMillis(500))
                 .map { sequence ->


### PR DESCRIPTION
### Propositions 

Le controlleur n'a pas lieu d'exister sans sa dépendance donc je la mets dans le constructeur.

Concernant le nom des resources REST, je trouve que le pluriel a plus de sens, tu as les tweets sous `/tweets` et un tweet en particulier sous `/tweets/:id`.

Enfin, je ne ferais pas de distinction au niveau du nommage des routes entre l'API REST classique et l'API stream. Pour moi, c'est au client de préciser le header `Accept: text/event-stream` s'il veut du stream.